### PR TITLE
add "unstyled" to PrimeVueConfiguration intf

### DIFF
--- a/src/runtime/primevueConfig.ts
+++ b/src/runtime/primevueConfig.ts
@@ -125,6 +125,7 @@ export interface PrimeVueLocaleOptions {
   aria?: PrimeVueLocaleAriaOptions;
 }
 export interface PrimeVueConfiguration {
+  unstyled?: boolean;
   ripple?: boolean;
   inputStyle?: string;
   locale?: PrimeVueLocaleOptions;


### PR DESCRIPTION
I enabled the new [unstyled mode](https://primevue.org/unstyled) on primevue.config, and it worked as expected, but TypeScript is barking at me. This is my first ever contribution to a repo, so please forgive me if I did anything stupid...

![image](https://github.com/sfxcode/nuxt-primevue/assets/53072187/4578f542-01fb-410e-b0c3-e3e890be3180)
