### PR TITLE
Fixed typescript warning on showMessage

### DIFF
--- a/src/runtime/components/demo/PrimeDemoToast.vue
+++ b/src/runtime/components/demo/PrimeDemoToast.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useToast } from 'primevue/usetoast'
-
+import { ToastMessageOptions } from 'primevue/toast'
 const toast = useToast()
 
-const showMessage = (severity: string, summary: string, detail: string) => {
+const showMessage = (severity: ToastMessageOptions['severity'], summary: string, detail: string) => {
   toast.add({ severity, summary, detail, life: 3000 })
 }
 </script>


### PR DESCRIPTION
When running nuxi typecheck in my project that uses this library it fails because of:

```js
node_modules/@sfxcode/nuxt-primevue/dist/runtime/components/demo/PrimeDemoToast.vue:7:15 - error TS2322: Type 'string' is not assignable to type '"error" | "success" | "info" | "warn" | undefined'.
```

Which is the fault of https://github.com/sfxcode/nuxt-primevue/blob/main/src/runtime/components/demo/PrimeDemoToast.vue#L6

If we simply change it to use `ToastMessageOptions['severity']` and `import { ToastMessageOptions } from "primevue/toast";`

the typecheck passes successfully. 